### PR TITLE
Feature/11 aligned major version check to main

### DIFF
--- a/build_ut.sh
+++ b/build_ut.sh
@@ -20,37 +20,80 @@
 # *
 
 # Clone the Unit Testing Suit for this repo, it follows a standard convention
-# HAL Name is replaced with haltest, allowing this script to be part of the template for all
+# halif Name is by default to halif-test, allowing this script to be part of the template for all hals
+# This is a general configuration for ease, you can hard code it if that's the requirement
 
 # This will look up the last tag in the git repo, depending on the project this may require modification
-TEST_REPO=$(git remote -vv | head -n1 | awk -F ' ' '{print $2}' | sed 's/halif/halif-test/g')
+# We need to check for the old format, and also support either old or new depending on the repo.
+# Transition was from hal -> hal-test, new format is from halif -> halif-test
+# More Info : https://github.com/rdkcentral/ut-core/wiki/2.3.-Standards:-Performing-Changes-to-an-interface
 
-# Set default UT_PROJECT_VERSION to master
+# This script aims to provide the latest binary compatible version of the testing suite for a clean environment.
+# It supports automatic upgrades within the same major version (e.g., 1.x.x to 1.y.y). However, when a new major
+# version is released (e.g., 2.x.x), manual intervention is required to update UT_PROJECT_VERSION.
+# This precaution prevents potential test breakages caused by incompatible changes introduced in the new major version.
+# The script will choose highest version of the tags starting with ${UT_PROJECT_VERSION}. If it fails to find one, then
+# it falls back to the highest version available among tags
+
+TEST_REPO=$(git remote -vv | head -n1 | awk -F ' ' '{print $2}' | sed 's/halif/halif-test/g' | sed 's/hal-/haltest-/g' )
+DIR="."
+
+# Setting default UT_PROJECT_VERSION to 1.
 if [ -z "${UT_PROJECT_VERSION}" ]; then
-    UT_PROJECT_VERSION=master
+    UT_PROJECT_VERSION="1.3." #alternatively use : UT_PROJECT_VERSION=main ./build_ut.sh, to force build version main/master
 fi
 
-UT_DIR="./ut"
+# This function checks the latest version of UT project and recommends an upgrade if reuqired
+function check_next_revision()
+{
+    # Set default UT_SUITE_VERSION to best revision, if it's set then we don't need to tell you again
+    if [ -v ${UT_SUITE_VERSION} ]; then
+        UT_SUITE_VERSION=$(git tag | grep ^${UT_PROJECT_VERSION} | sort -r | head -n1)  # Selects the highest version of the tags starting with ${UT_PROJECT_VERSION}
+        UT_NEXT_VERSION=$(git tag | sort -r | head -n1)                                 # Selects the highest version from the tags
+        if [ -z ${UT_SUITE_VERSION} ]; then
+            UT_SUITE_VERSION="${UT_NEXT_VERSION}"                                       # Fallback if there is no version of tags are available starting with ${UT_PROJECT_VERSION}
+        fi
+        echo -e ${YELLOW}ut project version selected:[${UT_SUITE_VERSION}]${NC}
+        if [ "${UT_NEXT_VERSION}" != "${UT_SUITE_VERSION}" ]; then
+            echo -e ${RED}--- New Version of ut project released [${UT_NEXT_VERSION}] consider upgrading ---${NC}
+        fi
+    fi
+}
 
 # Simple help
 if [ "${1}" == "-h" ]; then
     echo "Script to build the unit testing suite"
     echo " build_ut.sh <clean> - clean the testing"
     echo " build_ut.sh TARGET=xxx - build the xxx version of the tests, linux/arm etc."
+    echo " build_ut.sh --dir xxx - Build Directory (must be first)"
     echo " build_ut.sh <noswitch> - build the linux version of tests using skeleton & stubs"
     exit 0
 fi
 
+PARAMS=$@
+if [ "${1}" == "--dir" ]; then
+    # Remove the --dir & the command from the switches
+    shift
+    DIR=${1}
+    shift
+fi
+
+UT_DIR="${DIR}/ut"
+
 # Check if the common document configuration is present, if not clone it
 if [ -d ${UT_DIR} ]; then
     pushd ${UT_DIR} > /dev/null
+    check_next_revision
     ./build.sh $@
     popd > /dev/null
 else
-    echo "Cloning unit Test Suite for this module"
+    echo "Cloning unit Test Suite for this module [${DIR}]"
+    mkdir -p ${DIR}
+    pushd ${DIR} > /dev/null
     git clone ${TEST_REPO} ut
-    pushd ${UT_DIR} > /dev/null
-    git checkout ${UT_PROJECT_VERSION}
+    cd ${UT_DIR}
+    check_next_revision
+    git checkout ${UT_SUITE_VERSION}
     popd > /dev/null
-    ./${0} $@
+    ./${0} ${PARAMS}
 fi

--- a/build_ut.sh
+++ b/build_ut.sh
@@ -40,7 +40,7 @@ DIR="."
 
 # Setting default UT_PROJECT_VERSION to 1.
 if [ -z "${UT_PROJECT_VERSION}" ]; then
-    UT_PROJECT_VERSION="1.3." #alternatively use : UT_PROJECT_VERSION=main ./build_ut.sh, to force build version main/master
+    UT_PROJECT_VERSION="1." #alternatively use : UT_PROJECT_VERSION=main ./build_ut.sh, to force build version main/master
 fi
 
 # This function checks the latest version of UT project and recommends an upgrade if reuqired

--- a/build_ut.sh
+++ b/build_ut.sh
@@ -40,7 +40,7 @@ DIR="."
 
 # Setting default UT_PROJECT_VERSION to 1.
 if [ -z "${UT_PROJECT_VERSION}" ]; then
-    UT_PROJECT_VERSION="1." #alternatively use : UT_PROJECT_VERSION=main ./build_ut.sh, to force build version main/master
+    UT_PROJECT_VERSION=main #alternatively use : UT_PROJECT_VERSION=main ./build_ut.sh, to force build version main/master
 fi
 
 # This function checks the latest version of UT project and recommends an upgrade if reuqired


### PR DESCRIPTION
HALIF header always choosing master, it should be upgraded to support aligned major version check. Pointing UT_PROJECT_VERSION to main